### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches: ["*"]


### PR DESCRIPTION
Potential fix for [https://github.com/alexaandru/confetti/security/code-scanning/1](https://github.com/alexaandru/confetti/security/code-scanning/1)

To fix the issue, add a `permissions:` key at the top level of the workflow, immediately after the `name:` (or below `on:`), to apply minimal, explicit permissions to all jobs. Since both "Test" and "Lint" only read repository contents and do not require any write permission, the minimal necessary is `contents: read`. No further permissions are required. Only the workflow file (.github/workflows/ci.yml) needs to be modified, and the `permissions:` block should be added as the second major property (after `name:` and before `on:` or after `on:`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
